### PR TITLE
Fix Microcontroller Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESP-WebUI [![Build Status](https://travis-ci.org/aenniw/ESP-WebUI.svg?branch=master)](https://travis-ci.org/aenniw/ESP-WebUI)
 
-Preact frontend for [ESP8226](https://github.com/aenniw/ESP8266)/[ESP32](https://github.com/aenniw/ESP32)
+Preact frontend for [ESP8266](https://github.com/aenniw/ESP8266)/[ESP32](https://github.com/aenniw/ESP32)
 
 <p align="center">
   <img src="./img/demo.gif" alt="UI demo"/>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esp-webui",
   "version": "0.3.0",
-  "description": "Preact frontend for ESP8226/ESP32",
+  "description": "Preact frontend for ESP8266/ESP32",
   "scripts": {
     "start": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --progress",
     "build": "mkdirp build && cross-env NODE_ENV=production webpack --progress",


### PR DESCRIPTION
I was wandering around the preact world and found your work, but this one little error nagged at me.

- replaces incorrect "ESP8226" name with correct "ESP8266" identifier where it appears.